### PR TITLE
fix(spark-chat): add cross-env for proper environment variable handling

### DIFF
--- a/packages/spark-chat/bin/cli.js
+++ b/packages/spark-chat/bin/cli.js
@@ -31,7 +31,7 @@ async function startServer() {
     
 
     execSync(
-      `cd ${__dirname}/starter_webui && npm install && BASE_URL=${
+      `cd ${__dirname}/starter_webui && npm install && npx cross-env BASE_URL=${
         options.url || 'BASE_URL'
       } TOKEN=${options.token || 'TOKEN'} npm run dev`,
       {


### PR DESCRIPTION
Add cross-env to ensure BASE_URL and TOKEN environment variables are properly set across different operating systems when running the dev command in starter_webui directory.

This would fix #36 and thus https://github.com/agentscope-ai/agentscope-runtime/issues/414

## 变更类型

- [ ] feat（新增功能）
- [x] fix（问题修复）
- [ ] docs（文档）
- [ ] chore（工程/构建/依赖）
- [ ] refactor（重构）
- [ ] perf（性能优化）
- [ ] test（测试）

## 影响范围（必填）

- [ ] `@agentscope-ai/design`（packages/spark-design）
- [x] `@agentscope-ai/chat`（packages/spark-chat）
- [ ] `@agentscope-ai/flow`（packages/spark-flow）
- [ ] 仅仓库工程（不影响 npm 包）

## 变更说明

Currently, the environment variables setting command in `agentscope-runtime-webui` is of unix style.
In order to make it compatible with windows, use `cross-env`.

## 验证方式

- [x] 本地已通过：`pnpm run lint`
- [x] 本地已通过：`pnpm run build`
- [ ] 本地已通过（如涉及）：`pnpm run docs:build`

## 发布影响（Maintainer 填）

- [ ] 需要发版
- [ ] 不需要发版

> 建议 PR 标题使用 Conventional Commits，例如：`feat(design): xxx`。
> 仓库会强制 Squash Merge，最终提交信息默认取 PR 标题。


