### PR TITLE
fix(spark-chat): fix starting `agentscope-runtime-webui` with npx in windows

### DIFF
--- a/packages/spark-chat/bin/cli.js
+++ b/packages/spark-chat/bin/cli.js
@@ -2,6 +2,7 @@
 
 const { program } = require('commander');
 const { execSync } = require('child_process');
+const path = require('path');
 
 function execSyncSafe(command) {
   try {
@@ -28,14 +29,18 @@ async function startServer() {
     execSyncSafe(
       `npx decompress-cli ${__dirname}/starter_webui.zip --out-dir ${__dirname}`,
     );
-    
 
+    const targetDir = path.join(__dirname, 'starter_webui');
     execSync(
-      `cd ${__dirname}/starter_webui && npm install && npx cross-env BASE_URL=${
-        options.url || 'BASE_URL'
-      } TOKEN=${options.token || 'TOKEN'} npm run dev`,
+      `npm install && npm run dev`,
       {
+        cwd: targetDir,
         stdio: 'inherit',
+        env: {
+          ...process.env,
+          BASE_URL: options.url || 'BASE_URL',
+          TOKEN: options.token || 'TOKEN'
+        }
       },
     );
 


### PR DESCRIPTION
## 变更类型

- [ ] feat（新增功能）
- [x] fix（问题修复）
- [ ] docs（文档）
- [ ] chore（工程/构建/依赖）
- [ ] refactor（重构）
- [ ] perf（性能优化）
- [ ] test（测试）

## 影响范围（必填）

- [ ] `@agentscope-ai/design`（packages/spark-design）
- [x] `@agentscope-ai/chat`（packages/spark-chat）
- [ ] `@agentscope-ai/flow`（packages/spark-flow）
- [ ] 仅仓库工程（不影响 npm 包）

## 变更说明

It turn out #40 only allows starting `agentscope-runtime-webui` in windows from locally installed one.
`npx @agentscope-ai/chat agentscope-runtime-webui` is still buggy.

In this pull request, native ability of setting environmental variables and changing working directory from `execSync` is used in place of `cross-env`.

#36 should be fully fixed.

I have tested `npx` on windows and on ubuntu (wsl) this time. However, please do test more before merging or rejecting.

## 验证方式

- [x] 本地已通过：`pnpm run lint`
- [x] 本地已通过：`pnpm run build`
- [ ] 本地已通过（如涉及）：`pnpm run docs:build`

## 发布影响（Maintainer 填）

- [ ] 需要发版
- [ ] 不需要发版

> 建议 PR 标题使用 Conventional Commits，例如：`feat(design): xxx`。
> 仓库会强制 Squash Merge，最终提交信息默认取 PR 标题。


