### PR TITLE
fix: Empty组件中的Illustrate组件不使用Symbol,直接使用内联svg实现

### DIFF
--- a/packages/spark-design/package.json
+++ b/packages/spark-design/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentscope-ai/design",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "AgentScope Spark Design - UI Library for AgentScope AI",
   "repository": {
     "type": "git",

--- a/packages/spark-design/src/components/commonComponents/Empty/svg/Illustrate.tsx
+++ b/packages/spark-design/src/components/commonComponents/Empty/svg/Illustrate.tsx
@@ -1,5 +1,4 @@
-import useToken from 'antd/es/theme/useToken';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface IProps {
   /**
@@ -10,148 +9,107 @@ interface IProps {
    * @description 映射关系
    */
   tokenMap?: Record<string, string>;
-
+  /** 自定义类名 */
   className?: string;
-
+  /** 尺寸 */
   size: number | string;
-}
-
-const SVG_NS = 'http://www.w3.org/2000/svg';
-const XLINK_NS = 'http://www.w3.org/1999/xlink';
-
-// 避免多实例并发注入时互相覆盖：用任务 Map 去重同一个 svgId 的加载
-const svgSymbolTasks = new Map<string, Promise<void>>();
-
-let svgContainer: SVGSVGElement | null = null;
-if (typeof document !== 'undefined') {
-  svgContainer = document.querySelector('#empty-svg-container');
 }
 
 function escapeRegExp(str: string) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function toBase64Url(input: string) {
-  // btoa 仅支持 latin1，这里 input 是 URL（ascii），可直接使用
-  // 转成 base64url，避免 id 中出现 + / =
-  return btoa(input).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+/** 模块级缓存：svgUrl -> 原始 SVG 文本，避免重复网络请求 */
+const svgRawCache = new Map<string, string>();
+/** 模块级请求去重：svgUrl -> Promise，避免并发重复请求 */
+const svgFetchTasks = new Map<string, Promise<string>>();
+
+/**
+ * 获取 SVG 原始文本，带缓存和请求去重
+ */
+async function fetchSvgText(url: string): Promise<string> {
+  const cached = svgRawCache.get(url);
+  if (cached !== undefined) return cached;
+
+  const existing = svgFetchTasks.get(url);
+  if (existing) return existing;
+
+  const task = (async () => {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const text = await res.text();
+    svgRawCache.set(url, text);
+    return text;
+  })().finally(() => {
+    svgFetchTasks.delete(url);
+  });
+
+  svgFetchTasks.set(url, task);
+  return task;
 }
 
-function ensureSvgContainer() {
-  if (svgContainer || typeof document === 'undefined') return svgContainer;
-
-  const container = document.createElement('div');
-  container.innerHTML = '<svg></svg>';
-  svgContainer = container.querySelector('svg') as SVGSVGElement;
-  svgContainer.id = 'empty-svg-container';
-  svgContainer.setAttribute('aria-hidden', 'true');
-  svgContainer.style.position = 'absolute';
-  svgContainer.style.width = '0';
-  svgContainer.style.height = '0';
-  svgContainer.style.overflow = 'hidden';
-  document.body.insertBefore(svgContainer, document.body.firstChild);
-  return svgContainer;
-}
-
-function ensureSymbol(svgId: string) {
-  if (!svgContainer) return null;
-  const existed = document.getElementById(svgId);
-  let symbol = (existed as unknown as SVGSymbolElement) || null;
-  if (symbol) return symbol;
-
-  symbol = document.createElementNS(SVG_NS, 'symbol') as SVGSymbolElement;
-  symbol.id = svgId;
-  symbol.setAttribute('data-loaded', 'false');
-  svgContainer.appendChild(symbol);
-  return symbol;
+/**
+ * 将原始 SVG 文本中的颜色替换为 CSS 变量
+ */
+function replaceSvgColors(raw: string, tokenMap: Record<string, string>): string {
+  let result = raw;
+  Object.keys(tokenMap).forEach((key) => {
+    result = result.replace(new RegExp(escapeRegExp(key), 'g'), tokenMap[key]);
+  });
+  return result;
 }
 
 export default function Illustrate(props: IProps) {
-  const [ , , , , cssVar] = useToken();
   const { svgUrl, tokenMap = {}, className, size } = props;
   const isSvg = svgUrl.includes('.svg');
-  const [svgString, setSvgString] = useState('');
+  const [rawSvg, setRawSvg] = useState<string>(() => svgRawCache.get(svgUrl) || '');
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    ensureSvgContainer();
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
   useEffect(() => {
-    if (svgContainer && cssVar?.key) {
-      svgContainer.classList.forEach(key => svgContainer.classList.remove(key));
-      svgContainer.classList.add(cssVar.key);
-    }
-  }, [cssVar?.key]);
+    if (!isSvg) return;
 
-  useEffect(() => {
-    if (!isSvg) {
+    // 如果缓存中已有，直接使用
+    const cached = svgRawCache.get(svgUrl);
+    if (cached) {
+      setRawSvg(cached);
       return;
     }
 
-    ensureSvgContainer();
-    if (!svgContainer) return;
-
-    const svgId = toBase64Url(svgUrl);
-    setSvgString(
-      `<svg width="100%" height="100%"><use href="#${svgId}" xlink:href="#${svgId}"></use></svg>`,
-    );
-
-    const symbol = ensureSymbol(svgId);
-    if (!symbol) return;
-
-    // 已经加载过，直接复用
-    if (symbol.getAttribute('data-loaded') === 'true') return;
-
-    // 同一个 svgId 的并发请求去重
-    if (!svgSymbolTasks.has(svgId)) {
-      const task = (async () => {
-        try {
-          const res = await fetch(svgUrl);
-          if (!res.ok) {
-            throw new Error(`HTTP ${res.status}`);
-          }
-          const raw = await res.text();
-
-          let str = raw;
-          Object.keys(tokenMap).forEach((key) => {
-            str = str.replace(new RegExp(escapeRegExp(key), 'g'), tokenMap[key]);
-          });
-
-          // 提取 viewBox
-          const viewBoxMatch = str.match(/viewBox="([^"]*)"/);
-          const viewBox = viewBoxMatch ? viewBoxMatch[1] : '';
-
-          // 只保留 <svg> 内部内容
-          let symbolContentStr = str.replace(/<svg[^>]*>/, '');
-          symbolContentStr = symbolContentStr.replace(/<\/svg>/, '');
-
-          if (viewBox) {
-            symbol.setAttribute('viewBox', viewBox);
-          }
-
-          // 使用 DOM API 写入，避免 innerHTML 触发 svgContainer 重建
-          symbol.innerHTML = symbolContentStr;
-          symbol.setAttribute('data-loaded', 'true');
-          symbol.removeAttribute('data-error');
-        } catch (err) {
-          // 失败时保证不会进入“空壳已存在但永远不再加载”的状态
-          symbol.setAttribute('data-loaded', 'false');
-          symbol.setAttribute('data-error', 'true');
-          symbol.innerHTML = '';
-          // eslint-disable-next-line no-console
-          console.warn('[SparkDesign][Empty][Illustrate] load svg failed:', svgUrl, err);
+    fetchSvgText(svgUrl)
+      .then((text) => {
+        if (mountedRef.current) {
+          setRawSvg(text);
         }
-      })().finally(() => {
-        svgSymbolTasks.delete(svgId);
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn('[SparkDesign][Empty][Illustrate] load svg failed:', svgUrl, err);
       });
-
-      svgSymbolTasks.set(svgId, task);
-    }
   }, [svgUrl]);
 
-  if (isSvg) {
-    return <div className={className} dangerouslySetInnerHTML={{ __html: svgString }} style={{ width: size, height: size }} />;
+  if (!isSvg) {
+    return <img src={svgUrl} className={className} style={{ width: size, height: size }} />;
   }
 
-  return <img src={svgUrl} className={className} style={{ width: size, height: size }} />;
+  if (!rawSvg) return null;
+
+  // 每次渲染时根据当前 tokenMap 做颜色替换
+  const svgString = replaceSvgColors(rawSvg, tokenMap);
+
+  return (
+    <div
+      className={className}
+      dangerouslySetInnerHTML={{ __html: svgString }}
+      style={{ width: size, height: size }}
+    />
+  );
 }


### PR DESCRIPTION
## 变更类型

- [ ] feat（新增功能）
- [x] fix（问题修复）
- [ ] docs（文档）
- [ ] chore（工程/构建/依赖）
- [ ] refactor（重构）
- [ ] perf（性能优化）
- [ ] test（测试）

## 影响范围（必填）

- [x] `@agentscope-ai/design`（packages/spark-design）
- [ ] `@agentscope-ai/chat`（packages/spark-chat）
- [ ] `@agentscope-ai/flow`（packages/spark-flow）
- [ ] `@agentscope-ai/clawd-chat-ui`（packages/clawd-chat-ui）
- [ ] 仅仓库工程（不影响 npm 包）

## 变更说明

<!-- 简述做了什么、为什么做、怎么验证 -->

## 验证方式

- [x] 本地已通过：`pnpm run lint`
- [x] 本地已通过：`pnpm run build`
- [x] 本地已通过（如涉及）：`pnpm run docs:build`

## 发布影响（Maintainer 填）

- [x] 需要发版
- [ ] 不需要发版

> 建议 PR 标题使用 Conventional Commits，例如：`feat(design): xxx`。
> 仓库会强制 Squash Merge，最终提交信息默认取 PR 标题。


