### PR TITLE
Enhance chat request handling with abort signal support

### DIFF
--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatRequest.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatRequest.tsx
@@ -61,11 +61,13 @@ export default function useChatRequest(options: UseChatRequestOptions) {
     // 使用 ref.current 获取最新的 apiOptions
     const currentApiOptions = apiOptionsRef.current;
     const { enableHistoryMessages = false } = currentApiOptions;
+    const abortSignal = currentQARef.current.abortController?.signal;
     let response
     try {
       response = currentApiOptions.fetch ? await currentApiOptions.fetch({
         input: historyMessages,
         biz_params,
+        signal: abortSignal,
       }) : await fetch(currentApiOptions.baseURL, {
         method: 'POST',
         headers: {
@@ -78,6 +80,7 @@ export default function useChatRequest(options: UseChatRequestOptions) {
           stream: true,
           biz_params,
         }),
+        signal: abortSignal,
       });
     } catch (error) {
     }

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.ts
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.ts
@@ -30,6 +30,7 @@ export interface IAgentScopeRuntimeWebUIAPIOptions {
   fetch?: (data: {
     input: any[];
     biz_params?: IAgentScopeRuntimeWebUIInputData['biz_params'];
+    signal?: AbortSignal;
   }) => Promise<Response>;
 
   cancel?: (data: {

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/starter/index.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/starter/index.tsx
@@ -72,6 +72,12 @@ export default function () {
         ...optionsConfig.theme,
         rightHeader,
       },
+      api: {
+        ...optionsConfig.api,
+        cancel: (data) => {
+          console.log('cancel', data);
+        },
+      },
     };
   }, [optionsConfig]);
 

--- a/packages/spark-design/src/components/commonComponents/ConfigProvider/index.tsx
+++ b/packages/spark-design/src/components/commonComponents/ConfigProvider/index.tsx
@@ -79,7 +79,6 @@ function SparkConfigProvider(props: SparkConfigProviderProps) {
         sparkPrefix: `${prefix}-${DEFAULT_SPARK_PREFIX}`, // spark组件的前缀
         prefix,
       };
-      console.log('debug', `${prefix}-${DEFAULT_SPARK_PREFIX}`);
     }
     setCommonConfig({
       ...newCommonConfig,

--- a/packages/spark-design/src/components/commonComponents/Slider/Input/index.tsx
+++ b/packages/spark-design/src/components/commonComponents/Slider/Input/index.tsx
@@ -24,7 +24,6 @@ export type SliderInputProps = Omit<
 
 export default function SliderSelector(props: SliderInputProps) {
   const { sparkPrefix } = getCommonConfig();
-  console.log('debug sparkPrefix in SliderSelector', sparkPrefix);
 
   const { styles, classNames, sliderProps, inputNumberProps, ...restProps } =
     props;


### PR DESCRIPTION
- Added support for AbortSignal in the chat request API options to enable request cancellation.
- Updated the useChatRequest hook to utilize the abort signal when making fetch requests.
- Implemented a cancel function in the API configuration for better request management.

## 变更类型

- [ ] feat（新增功能）
- [ ] fix（问题修复）
- [ ] docs（文档）
- [ ] chore（工程/构建/依赖）
- [ ] refactor（重构）
- [ ] perf（性能优化）
- [ ] test（测试）

## 影响范围（必填）

- [ ] `@agentscope-ai/design`（packages/spark-design）
- [ ] `@agentscope-ai/chat`（packages/spark-chat）
- [ ] `@agentscope-ai/flow`（packages/spark-flow）
- [ ] `@agentscope-ai/clawd-chat-ui`（packages/clawd-chat-ui）
- [ ] 仅仓库工程（不影响 npm 包）

## 变更说明

<!-- 简述做了什么、为什么做、怎么验证 -->

## 验证方式

- [ ] 本地已通过：`pnpm run lint`
- [ ] 本地已通过：`pnpm run build`
- [ ] 本地已通过（如涉及）：`pnpm run docs:build`

## 发布影响（Maintainer 填）

- [ ] 需要发版
- [ ] 不需要发版

> 建议 PR 标题使用 Conventional Commits，例如：`feat(design): xxx`。
> 仓库会强制 Squash Merge，最终提交信息默认取 PR 标题。


