### PR TITLE
docs(chat): remove redundant custom cards capability table from docs

### DIFF
--- a/packages/spark-chat/docs/documents/agentscope-runtime-webui.en-US.md
+++ b/packages/spark-chat/docs/documents/agentscope-runtime-webui.en-US.md
@@ -352,13 +352,6 @@ export default function App() {
 
 ## Custom Cards
 
-`AgentScopeRuntimeWebUI` provides two custom rendering capabilities:
-
-| Capability | Config | Matching | Use Case |
-| --- | --- | --- | --- |
-| Custom Cards | `cards` | `code` field in messages | `component_call` messages, rich interactive UI |
-| Custom Tool Render | `customToolRenderConfig` | `name` field of tool calls | Visualization of `plugin_call` / `mcp_call` tool results |
-
 The scaffold includes a complete weather card example (`src/components/Cards/Weather.tsx`). The following documentation uses it to illustrate the full development flow for custom tool rendering.
 
 ---

--- a/packages/spark-chat/docs/documents/agentscope-runtime-webui.zh-CN.md
+++ b/packages/spark-chat/docs/documents/agentscope-runtime-webui.zh-CN.md
@@ -354,13 +354,6 @@ export default function App() {
 
 ## 自定义卡片
 
-`AgentScopeRuntimeWebUI` 提供了两种自定义渲染能力：
-
-| 能力 | 配置项 | 匹配方式 | 适用场景 |
-| --- | --- | --- | --- |
-| 自定义卡片 | `cards` | 消息中的 `code` 字段 | `component_call` 类型消息，展示富交互 UI |
-| 自定义工具渲染 | `customToolRenderConfig` | 工具调用的 `name` 字段 | `plugin_call` / `mcp_call` 等工具调用结果的可视化 |
-
 脚手架中内置了一个完整的天气卡片示例（`src/components/Cards/Weather.tsx`），以下文档以此为例介绍自定义工具渲染的完整开发流程。
 
 ---


### PR DESCRIPTION
## Change Type

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [x] docs (documentation)
- [ ] chore (build/deps/infra)
- [ ] refactor (code refactoring)
- [ ] perf (performance)
- [ ] test (tests)

## Affected Scope (Required)

- [ ] `@agentscope-ai/design` (`packages/spark-design`)
- [x] `@agentscope-ai/chat` (`packages/spark-chat`)
- [ ] `@agentscope-ai/flow` (`packages/spark-flow`)
- [ ] `@agentscope-ai/clawd-chat-ui` (`packages/clawd-chat-ui`)
- [ ] Repository-only changes (no npm package impact)

## Description

Removes the custom cards capability summary table from both en-US and zh-CN versions of the `AgentScopeRuntimeWebUI` documentation. The table was redundant with the detailed Weather card walkthrough that immediately follows, and its removal streamlines the docs without losing any information.

## Validation

- [ ] Verified locally: `pnpm run lint`
- [ ] Verified locally: `pnpm run build`
- [x] Verified locally (if applicable): `pnpm run docs:build`

## Release Impact (Maintainer)

- [ ] Release required
- [x] No release required

Made with [Cursor](https://cursor.com)