### PR TITLE
fix(chat): optimize runtime tool message merging

### DIFF
--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Builder.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Builder.tsx
@@ -7,6 +7,7 @@ class AgentScopeRuntimeResponseBuilder {
 
   static mergeToolMessages(messages: IAgentScopeRuntimeMessage[]) {
     const bufferMessagesMap = new Map<string, IDataContent>();
+    const bufferMessageIndexesMap = new Map<string, number[]>();
     let resMessages: IAgentScopeRuntimeMessage[] = [];
 
     for (const message of messages) {
@@ -18,6 +19,9 @@ class AgentScopeRuntimeResponseBuilder {
         }>;
         const key = content.data.call_id || content.data.name;
         bufferMessagesMap.set(key, content);
+        const indexes = bufferMessageIndexesMap.get(key) || [];
+        indexes.push(resMessages.length);
+        bufferMessageIndexesMap.set(key, indexes);
         resMessages.push(message);
 
       } else if (AgentScopeRuntimeResponseBuilder.maybeToolOutput(message) && message.content?.length) {
@@ -30,8 +34,11 @@ class AgentScopeRuntimeResponseBuilder {
 
         if (bufferContent) {
 
-          resMessages = resMessages.map(i => {
-            if (!AgentScopeRuntimeResponseBuilder.maybeToolInput(i)) return i;
+          const indexes = bufferMessageIndexesMap.get(key) || [];
+          indexes.forEach(index => {
+            const i = resMessages[index];
+            if (!i) return;
+            if (!AgentScopeRuntimeResponseBuilder.maybeToolInput(i)) return;
             const preContent = i.content[0] as IDataContent<{
               name: string;
               call_id?: string;
@@ -40,9 +47,7 @@ class AgentScopeRuntimeResponseBuilder {
             const preKey = preContent.data.call_id || preContent.data.name;
 
             if (preKey === key) {
-              return { ...message, content: [...i.content, content] };
-            } else {
-              return i;
+              resMessages[index] = { ...message, content: [...i.content, content] };
             }
           });
         }


### PR DESCRIPTION
## 变更类型

  - [ ] feat（新增功能）
  - [ ] fix（问题修复）
  - [ ] docs（文档）
  - [ ] chore（工程/构建/依赖）
  - [ ] refactor（重构）
  - [x] perf（性能优化）
  - [ ] test（测试）

  ## 影响范围（必填）

  - [ ] `@agentscope-ai/design`（packages/spark-design）
  - [x] `@agentscope-ai/chat`（packages/spark-chat）
  - [ ] `@agentscope-ai/flow`（packages/spark-flow）
  - [ ] `@agentscope-ai/clawd-chat-ui`（packages/clawd-chat-ui）
  - [ ] 仅仓库工程（不影响 npm 包）

  ## 变更说明

  优化 `AgentScopeRuntimeResponseBuilder.mergeToolMessages()` 的 tool output 合并逻辑。

  之前每次匹配 tool output 时都会对 `resMessages` 做全量 `.map(...)` 扫描，在流式响应不断 `updateMessage()`
  的场景下，大量 tool call / thinking card 会导致 response card 反复重算。现在改为在收集 tool input 时记录
  `call_id || name` 对应的消息索引，tool output 到达时只访问对应索引，避免重复全量扫描。

  接口和匹配语义保持不变：

  - `call_id || name` 的 key 规则不变
  - output-before-input 的行为不变
  - 相同 key 的多个 tool input 兼容原有合并行为
  - 未改动公开 API

  本地 mock + Playwright benchmark 对比：

  - 120 tool calls + 24 thinking cards + 180 streamed chunks：
    - merge visits: `4,607,820 -> 28,980`
    - browser merge total mean/pass: `~132.7ms -> ~17.1ms`

  - 200 tool calls + 40 thinking cards + 240 streamed chunks：
    - merge visits: `18,099,500 -> 68,300`
    - browser merge total: `~510.4ms -> ~29.7ms`

  ## 验证方式

  - [x] 本地已通过：`pnpm run lint`
  - [x] 本地已通过：`pnpm run build`
  - [x] 本地已通过（如涉及）：`pnpm run docs:build`

  额外验证：

  - 已通过本地 mock 场景验证 tool input/output 合并行为
  - 已使用 Playwright browser benchmark 模拟大 response card 流式渲染性能
  - benchmark / 临时测试文件未纳入提交

  ## 发布影响（Maintainer 填）

  - [ ] 需要发版
  - [ ] 不需要发版