### PR TITLE
feat(AgentScopeRuntimeWebUI): tool_call & plugin_call & mcp_call支持流式展示

### DIFF
--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Builder.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Builder.tsx
@@ -157,7 +157,27 @@ class AgentScopeRuntimeResponseBuilder {
           } else if (data.type === AgentScopeRuntimeContentType.IMAGE) {
             (lastContent as IImageContent).image_url = (data as IImageContent).image_url;
           } else if (data.type === AgentScopeRuntimeContentType.DATA) {
-            (lastContent as IDataContent).data = (data as IDataContent).data;
+            const isStreamingToolInput = [
+              AgentScopeRuntimeMessageType.PLUGIN_CALL,
+              AgentScopeRuntimeMessageType.TOOL_CALL,
+              AgentScopeRuntimeMessageType.MCP_CALL,
+            ].includes(msg.type as AgentScopeRuntimeMessageType);
+
+            if (isStreamingToolInput) {
+              const oldData = (lastContent as IDataContent).data || {};
+              const newData = (data as IDataContent).data || {};
+              const merged: Record<string, any> = { ...oldData };
+              for (const [key, value] of Object.entries(newData)) {
+                if (typeof value === 'string' && typeof merged[key] === 'string') {
+                  merged[key] = merged[key] + value;
+                } else {
+                  merged[key] = value;
+                }
+              }
+              (lastContent as IDataContent).data = merged;
+            } else {
+              (lastContent as IDataContent).data = (data as IDataContent).data;
+            }
           }
         } else {
           msg.content.push(data);

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Tool.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Tool.tsx
@@ -1,11 +1,27 @@
-import React from "react";
-import { AgentScopeRuntimeRunStatus, IAgentScopeRuntimeMessage, IDataContent } from "../types";
+import React, { useEffect, useState } from "react";
+import { AgentScopeRuntimeMessageType, AgentScopeRuntimeRunStatus, IAgentScopeRuntimeMessage, IDataContent } from "../types";
 import { ToolCall } from '@agentscope-ai/chat';
 import { useChatAnywhereOptions } from "../../Context/ChatAnywhereOptionsContext";
 import Approval from "./Approval";
 
+// output展示后，2s自动关闭
+const OUTPUT_AUTO_COLLAPSE_MS = 2000;
+
 const Tool = React.memo(function ({ data, isApproval = false }: { data: IAgentScopeRuntimeMessage, isApproval?: boolean }) {
   const customToolRenderConfig = useChatAnywhereOptions(v => v.customToolRenderConfig) || {};
+
+  const isOutput = [
+    AgentScopeRuntimeMessageType.PLUGIN_CALL_OUTPUT,
+    AgentScopeRuntimeMessageType.TOOL_CALL_OUTPUT,
+    AgentScopeRuntimeMessageType.MCP_CALL_OUTPUT,
+  ].includes(data.type);
+
+  const [autoCollapsed, setAutoCollapsed] = useState(false);
+  useEffect(() => {
+    if (!isOutput || autoCollapsed) return;
+    const timer = setTimeout(() => setAutoCollapsed(true), OUTPUT_AUTO_COLLAPSE_MS);
+    return () => clearTimeout(timer);
+  }, [isOutput, autoCollapsed]);
 
   if (!data.content?.length) return null;
   const content = data.content as IDataContent<{
@@ -19,13 +35,21 @@ const Tool = React.memo(function ({ data, isApproval = false }: { data: IAgentSc
   const serverLabel = `${content[0].data.server_label ? content[0].data.server_label + ' / ' : ''}`
   const title = `${serverLabel}${toolName}`
 
+  const isInput = [
+    AgentScopeRuntimeMessageType.PLUGIN_CALL,
+    AgentScopeRuntimeMessageType.TOOL_CALL,
+    AgentScopeRuntimeMessageType.MCP_CALL,
+  ].includes(data.type);
+
+  const defaultOpen = isInput || (isOutput && !autoCollapsed);
+
   let node
 
   if (customToolRenderConfig[toolName]) {
     const C = customToolRenderConfig[toolName];
     node = <C data={data} />
   } else {
-    node = <ToolCall loading={loading} defaultOpen={false} title={title === 'undefined' ? '' : title} input={content[0]?.data?.arguments} output={content[1]?.data?.output}></ToolCall>
+    node = <ToolCall key={autoCollapsed ? 'collapsed' : 'open'} loading={loading} defaultOpen={defaultOpen} title={title === 'undefined' ? '' : title} input={content[0]?.data?.arguments} output={content[1]?.data?.output}></ToolCall>
   }
 
   return <>
@@ -36,4 +60,3 @@ const Tool = React.memo(function ({ data, isApproval = false }: { data: IAgentSc
 
 
 export default Tool;
-


### PR DESCRIPTION
## 变更类型

- [✅] feat（新增功能）
- [ ] fix（问题修复）
- [ ] docs（文档）
- [ ] chore（工程/构建/依赖）
- [ ] refactor（重构）
- [ ] perf（性能优化）
- [ ] test（测试）

## 影响范围（必填）

- [ ] `@agentscope-ai/design`（packages/spark-design）
- [✅] `@agentscope-ai/chat`（packages/spark-chat）
- [ ] `@agentscope-ai/flow`（packages/spark-flow）
- [ ] `@agentscope-ai/clawd-chat-ui`（packages/clawd-chat-ui）
- [ ] 仅仓库工程（不影响 npm 包）

## 变更说明

tool_call plugin_call mcp_call的input数据流式展示，output暂时不变

## 验证方式

- [✅] 本地已通过：`pnpm run lint`
- [✅] 本地已通过：`pnpm run build`
- [ ] 本地已通过（如涉及）：`pnpm run docs:build`

## 发布影响（Maintainer 填）

- [ ] 需要发版
- [ ] 不需要发版

> 建议 PR 标题使用 Conventional Commits，例如：`feat(design): xxx`。
> 仓库会强制 Squash Merge，最终提交信息默认取 PR 标题。


