### PR TITLE
fix(AgentScopeRuntimeWebUI): SSE race fixes, cancel UX, file click hook

### DIFF
--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Request/Actions.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Request/Actions.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { SparkCopyLine } from "@agentscope-ai/icons";
 import { AgentScopeRuntimeContentType, IAgentScopeRuntimeRequest } from "../types";
 import { Bubble } from "@agentscope-ai/chat";
@@ -27,10 +28,13 @@ export default function RequestActions(props: {
     },
   ] : [];
 
-  const actions = (requestActionsOptions.list || defaultActions).map(i => ({
-    ...i,
-    onClick: () => { i.onClick?.({ data: props.data }); },
-  }));
+  const actions = (requestActionsOptions.list || defaultActions).map(i => {
+    const res = { ...i } as any;
+    if (i.render) {
+      res.children = React.createElement(i.render, { data: props.data });
+    }
+    return { ...res, onClick: () => { i.onClick?.({ data: props.data }); } };
+  });
 
   if (!actions.length) return null;
 

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Request/Builder.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Request/Builder.tsx
@@ -101,6 +101,9 @@ class AgentScopeRuntimeRequestBuilder {
     }
 
     this.data = {
+      // Client-side send timestamp (seconds), aligns with response.created_at.
+      // Backend has not yet returned, so this represents the local send moment.
+      created_at: Math.floor(Date.now() / 1000),
       input: [
         {
           role: 'user',
@@ -113,7 +116,10 @@ class AgentScopeRuntimeRequestBuilder {
   }
 
   handleApproval(input) {
-    this.data = { input };
+    this.data = {
+      created_at: Math.floor(Date.now() / 1000),
+      input,
+    };
     return this.data;
   }
 }

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Request/Card.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Request/Card.tsx
@@ -74,7 +74,7 @@ export default function AgentScopeRuntimeRequestCard(props: {
       }
       return p;
     }, []);
-  }, [props.data.input, onFileClick]);
+  }, [props.data.input, onFileCardClick]);
 
   if (!cards?.length) return null;
 

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Request/Card.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Request/Card.tsx
@@ -3,10 +3,13 @@ import { AgentScopeRuntimeContentType, IAgentScopeRuntimeRequest } from '../type
 import { useMemo } from 'react';
 import { Bubble } from '@agentscope-ai/chat';
 import Actions from './Actions';
+import { useChatAnywhereOptions } from '../../Context/ChatAnywhereOptionsContext';
 
 export default function AgentScopeRuntimeRequestCard(props: {
   data: IAgentScopeRuntimeRequest;
 }) {
+  const onFileCardClick = useChatAnywhereOptions(v => v.api?.onFileCardClick);
+
   const cards = useMemo(() => {
 
     return props.data.input[0].content.reduce<any>((p, c) => {
@@ -63,6 +66,7 @@ export default function AgentScopeRuntimeRequestCard(props: {
           p.push({
             code: 'Files',
             data: [{ url: c.file_url, name: c.file_name || c.fileName, size: c.file_size }],
+            onClick: onFileCardClick,
           });
         } else {
           fileCard.data.push({ url: c.file_url, name: c.file_name || c.fileName, size: c.file_size });
@@ -70,7 +74,7 @@ export default function AgentScopeRuntimeRequestCard(props: {
       }
       return p;
     }, []);
-  }, [props.data.input]);
+  }, [props.data.input, onFileClick]);
 
   if (!cards?.length) return null;
 

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Actions.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Actions.tsx
@@ -40,7 +40,7 @@ export default function Tools(props: {
 
   const actions = compact([
     ...actionsOptionsList.map(i => {
-      const res = i;
+      const res = { ...i } as any;
 
       if (i.render) {
         res.children = React.createElement(i.render, { data: props });

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Builder.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Builder.tsx
@@ -105,10 +105,41 @@ class AgentScopeRuntimeResponseBuilder {
 
   handleResponse(data: IAgentScopeRuntimeResponse) {
     this.data = produce(this.data, (draft) => {
-      if (!data.output) {
-        data.output = [];
-      }
+      const existingOutput = draft.output || [];
+      const incomingOutput = data.output;
+
       Object.assign(draft, data);
+
+      // If incoming response has no output or empty output, preserve the
+      // accumulated output from streaming to avoid losing intermediate
+      // tool-call messages that were already collected.
+      if (!incomingOutput || incomingOutput.length === 0) {
+        draft.output = existingOutput;
+      } else if (existingOutput.length > 0) {
+        // Merge by id: prefer the version with non-empty content to avoid
+        // a partial-update response wiping out previously accumulated
+        // tool-call data (Bug 2 of issue #4644).
+        const existingMap = new Map(existingOutput.map(m => [m.id, m]));
+        const incomingIds = new Set(incomingOutput.map(m => m.id));
+        const merged = incomingOutput.map(incoming => {
+          const existing = existingMap.get(incoming.id);
+          if (!existing) return incoming;
+          // Prefer the message with content already populated.
+          const incomingHasContent = incoming.content?.length > 0;
+          const existingHasContent = existing.content?.length > 0;
+          if (existingHasContent && !incomingHasContent) {
+            return { ...incoming, content: existing.content };
+          }
+          return incoming;
+        });
+        // Append existing-only messages (not present in incoming).
+        for (const existing of existingOutput) {
+          if (!incomingIds.has(existing.id)) {
+            merged.push(existing);
+          }
+        }
+        draft.output = merged;
+      }
     });
   }
 

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Message.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Message.tsx
@@ -9,6 +9,7 @@ import { useChatAnywhereOptions } from "../../Context/ChatAnywhereOptionsContext
 
 const Message = React.memo(function ({ data }: { data: IAgentScopeRuntimeMessage }) {
   const replaceMediaURL = useChatAnywhereOptions(v => v.api?.replaceMediaURL);
+  const onFileCardClick = useChatAnywhereOptions(v => v.api?.onFileCardClick);
   const formatMediaURL = React.useCallback((url?: string) => {
     if (!url) return url;
     return replaceMediaURL?.(url) || url;
@@ -36,7 +37,7 @@ const Message = React.memo(function ({ data }: { data: IAgentScopeRuntimeMessage
               url: formatMediaURL(item.file_url),
               name: item.file_name || item.fileName || item.file_id,
               size: item.file_size,
-            }]}></Files>
+            }]} onClick={onFileCardClick}></Files>
           case AgentScopeRuntimeContentType.AUDIO:
             return <Audios key={index} data={[{ src: formatMediaURL(item.audio_url || item.data) }]}></Audios>
           default:

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/types.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/types.tsx
@@ -121,6 +121,7 @@ export interface IAgentScopeRuntimeError {
 }
 
 export interface IAgentScopeRuntimeRequest {
+  created_at?: number;
   input: {
     role: AgentScopeRuntimeMessageRole | string;
     type: AgentScopeRuntimeMessageType;

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatController.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatController.tsx
@@ -77,24 +77,29 @@ export default function useChatController() {
    * Handle user message submission.
    */
   const handleSubmit = useCallback<InputProps['onSubmit']>(async (data) => {
-    // 0. Increment requestId and abort any previous in-flight SSE.
-    //    We do NOT call the cancel API here — the user is sending a new
-    //    message, not explicitly cancelling. Cancel is only invoked from
-    //    handleCancel.
+    // 0. Abort any previous in-flight SSE. We do NOT call the cancel API here
+    //    — the user is sending a new message, not explicitly cancelling.
+    //    Cancel is only invoked from handleCancel.
     currentQARef.current.abortController?.abort();
-    const myRequestId = ++currentQARef.current.activeRequestId;
 
-    // 1. Ensure session exists
+    // 1. Ensure session exists FIRST. Bumping activeRequestId before this can
+    //    race with the [currentSessionId] effect below: ensureSession may set
+    //    a new sessionId, that effect then bumps activeRequestId again, and
+    //    our own myRequestId becomes stale → the guard after sleep(100) bails
+    //    out and the request is silently dropped. Establishing the session
+    //    first guarantees the effect (if any) has flushed before we snapshot
+    //    myRequestId.
     await sessionHandler.ensureSession(data.query);
+
+    const myRequestId = ++currentQARef.current.activeRequestId;
+    // Snapshot current session id for downstream SSE guard checks
+    currentQARef.current.activeSessionId = sessionHandler.getCurrentSessionId();
 
     // 2. Update session name (only for the first message)
     const messages = messageHandler.getMessages();
     if (sessionHandler.getCurrentSessionId()) {
       await sessionHandler.updateSessionName(data.query, messages);
     }
-
-    // Snapshot current session id for downstream SSE guard checks
-    currentQARef.current.activeSessionId = sessionHandler.getCurrentSessionId();
 
     // 3. Create user request message
     messageHandler.createRequestMessage(data);
@@ -118,8 +123,11 @@ export default function useChatController() {
 
   const handleApproval = useCallback(async ({ input }) => {
     currentQARef.current.abortController?.abort();
-    const myRequestId = ++currentQARef.current.activeRequestId;
+    // Snapshot the current session id BEFORE bumping requestId, then bump.
+    // Order matches handleSubmit so a concurrent session-change effect cannot
+    // invalidate myRequestId between the bump and the sleep guard below.
     currentQARef.current.activeSessionId = sessionHandler.getCurrentSessionId();
+    const myRequestId = ++currentQARef.current.activeRequestId;
 
     messageHandler.createApprovalMessage(input);
 
@@ -173,8 +181,8 @@ export default function useChatController() {
    */
   const handleRegenerate = useCallback(async (messageId: string) => {
     currentQARef.current.abortController?.abort();
-    const myRequestId = ++currentQARef.current.activeRequestId;
     currentQARef.current.activeSessionId = sessionHandler.getCurrentSessionId();
+    const myRequestId = ++currentQARef.current.activeRequestId;
 
     setLoading(true);
 
@@ -226,7 +234,21 @@ export default function useChatController() {
   // On session switch: abort current SSE (without notifying backend cancel)
   // and reset state. Also increment activeRequestId so any residual SSE
   // chunks from the old session are discarded, preventing cross-session leakage.
+  //
+  // IMPORTANT: only bump on a real session change. Running this on initial
+  // mount or when sessionId merely transitions from undefined → <same id>
+  // (e.g. after route navigate / refreshKey churn) would invalidate the
+  // myRequestId taken by an in-flight handleSubmit and silently drop the
+  // outgoing chat request — that was the regression that made existing
+  // sessions unable to send messages until a new chat was created.
   useEffect(() => {
+    const prevSessionId = currentQARef.current.activeSessionId;
+    if (!prevSessionId || prevSessionId === currentSessionId) {
+      // First mount, or no real switch: just sync the snapshot, do not bump.
+      currentQARef.current.activeSessionId = currentSessionId;
+      return;
+    }
+
     currentQARef.current.abortController?.abort();
     currentQARef.current = {
       request: undefined,

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatController.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatController.tsx
@@ -9,6 +9,7 @@ import { InputProps } from "../Input";
 import useChatMessageHandler from "./useChatMessageHandler";
 import useChatRequest from "./useChatRequest";
 import useChatSessionHandler from "./useChatSessionHandler";
+import { useChatAnywhereOptions } from "../../Context/ChatAnywhereOptionsContext";
 import ReactDOM from "react-dom";
 // import mockdata from '../../mock/mock.json'
 
@@ -18,12 +19,27 @@ import ReactDOM from "react-dom";
 export default function useChatController() {
   const setLoading = useContextSelector(ChatAnywhereInputContext, v => v.setLoading);
   const currentSessionId = useContextSelector(ChatAnywhereSessionsContext, v => v.currentSessionId);
+  const apiOptions = useChatAnywhereOptions(v => v.api);
+  const apiOptionsRef = useRef(apiOptions);
+  useEffect(() => {
+    apiOptionsRef.current = apiOptions;
+  }, [apiOptions]);
 
   const currentQARef = useRef<{
     request?: IAgentScopeRuntimeWebUIMessage;
     response?: IAgentScopeRuntimeWebUIMessage;
     abortController?: AbortController;
-  }>({});
+    /**
+     * 当前活跃 SSE 请求的唯一标识。每次发起新请求都会递增。
+     * processSSEResponse 在每次写入前会校验自己的 requestId 是否仍等于此值，
+     * 不匹配则停止写入，避免旧 SSE 流污染新会话/新消息（issue #4644 关联问题）。
+     */
+    activeRequestId: number;
+    /**
+     * 当前活跃 SSE 请求关联的会话 id 快照，用于切换会话时识别陈旧请求。
+     */
+    activeSessionId?: string;
+  }>({ activeRequestId: 0 });
 
   // 消息处理
   const messageHandler = useChatMessageHandler({ currentQARef });
@@ -58,6 +74,12 @@ export default function useChatController() {
    * 处理用户提交
    */
   const handleSubmit = useCallback<InputProps['onSubmit']>(async (data) => {
+    // 0. 递增 requestId，并中断上一个未完成的 SSE。
+    //    这里不调 cancel API，因为用户是发新消息而不是看取消，
+    //    cancel 仅在 handleCancel 中主动调用。
+    currentQARef.current.abortController?.abort();
+    const myRequestId = ++currentQARef.current.activeRequestId;
+
     // 1. 确保会话存在
     await sessionHandler.ensureSession(data.query);
 
@@ -67,10 +89,16 @@ export default function useChatController() {
       await sessionHandler.updateSessionName(data.query, messages);
     }
 
+    // 快照当前会话 id，后续 SSE 写入需校验
+    currentQARef.current.activeSessionId = sessionHandler.getCurrentSessionId();
+
     // 3. 创建用户请求消息
     messageHandler.createRequestMessage(data);
     setLoading(true);
     await sleep(100);
+
+    // 如果在 sleep 期间发生了会话切换/取消/新提交，requestId 已变，退出
+    if (myRequestId !== currentQARef.current.activeRequestId) return;
 
     // 4. 创建助手响应消息
     messageHandler.createResponseMessage();
@@ -79,39 +107,61 @@ export default function useChatController() {
     const historyMessages = messageHandler.getHistoryMessages();
     await sessionHandler.syncSessionMessages(messageHandler.getMessages());
 
-    await request(historyMessages, data.biz_params);
+    await request(historyMessages, data.biz_params, myRequestId);
     // mockRequest(mockdata);
-  }, [messageHandler, sessionHandler, request]);
+  }, [messageHandler, sessionHandler, request, setLoading]);
 
 
   const handleApproval = useCallback(async ({ input }) => {
+    currentQARef.current.abortController?.abort();
+    const myRequestId = ++currentQARef.current.activeRequestId;
+    currentQARef.current.activeSessionId = sessionHandler.getCurrentSessionId();
+
     messageHandler.createApprovalMessage(input);
 
     setLoading(true);
     await sleep(100);
 
+    if (myRequestId !== currentQARef.current.activeRequestId) return;
+
     messageHandler.createResponseMessage();
     const historyMessages = messageHandler.getHistoryMessages();
     await sessionHandler.syncSessionMessages(messageHandler.getMessages());
 
-    await request(historyMessages);
-  }, [messageHandler, sessionHandler, request]);
+    await request(historyMessages, undefined, myRequestId);
+  }, [messageHandler, sessionHandler, request, setLoading]);
 
   /**
    * 处理取消
    * 1. 标记 interrupted 并重置 UI（finishResponse）
-   * 2. abort SSE 连接 —— Stream 内部的 Promise.race 会立即 reject AbortError，
-   *    processSSEResponse 的 catch 会检测 interrupted 状态并调用 cancel API
+   * 2. 立即调用 cancel API，不依赖 SSE 下一个 chunk 发出取消（修复“点停止后后端仍在跑”问题）
+   * 3. abort SSE 连接
+   * 4. 递增 activeRequestId，让旧 SSE 的残留 chunk 不能再写入 UI
    */
   const handleCancel = useCallback(() => {
     finishResponse('interrupted');
+    const sessionId = sessionHandler.getCurrentSessionId();
+    const cancelFn = apiOptionsRef.current.cancel;
+    if (cancelFn && sessionId) {
+      try {
+        cancelFn({ session_id: sessionId });
+      } catch (e) {
+        console.error('cancel api failed:', e);
+      }
+    }
     currentQARef.current.abortController?.abort();
-  }, [finishResponse]);
+    // 递增 requestId，使未 abort 完的旧 SSE chunk 校验失败后被丢弃
+    currentQARef.current.activeRequestId += 1;
+  }, [finishResponse, sessionHandler]);
 
   /**
    * 处理重新生成
    */
   const handleRegenerate = useCallback(async (messageId: string) => {
+    currentQARef.current.abortController?.abort();
+    const myRequestId = ++currentQARef.current.activeRequestId;
+    currentQARef.current.activeSessionId = sessionHandler.getCurrentSessionId();
+
     setLoading(true);
 
     // 1. 移除旧消息
@@ -123,8 +173,8 @@ export default function useChatController() {
 
     // 3. 发起请求
     const historyMessages = messageHandler.getHistoryMessages();
-    await request(historyMessages);
-  }, [messageHandler, request]);
+    await request(historyMessages, undefined, myRequestId);
+  }, [messageHandler, request, sessionHandler, setLoading]);
 
   /**
    * 处理 SSE 重连（切回未完成的对话时）
@@ -134,11 +184,16 @@ export default function useChatController() {
   const handleReconnect = useCallback(async (sessionId: string) => {
     currentQARef.current.abortController?.abort();
     currentQARef.current.abortController = new AbortController();
+    const myRequestId = ++currentQARef.current.activeRequestId;
+    currentQARef.current.activeSessionId = sessionId;
     setLoading(true);
 
     messageHandler.createResponseMessage();
 
-    await reconnect(sessionId);
+    await reconnect(sessionId, myRequestId);
+
+    // 如果在 reconnect 期间会话被切走或发了新请求，requestId 已变，不要动 UI
+    if (myRequestId !== currentQARef.current.activeRequestId) return;
 
     // If the response is still in 'generating' state after reconnect completes,
     // onFinish() was never called (no response body, or stream closed without a completion event).
@@ -155,16 +210,21 @@ export default function useChatController() {
   }, [messageHandler, reconnect, setLoading]);
 
   // 监听会话切换，断开当前 SSE 连接（不通知后端取消）并重置状态
+  // 同时递增 activeRequestId，让旧会话未 abort 完的 SSE chunk 被丢弃，
+  // 防止“会话串台”问题。
   useEffect(() => {
     currentQARef.current.abortController?.abort();
     currentQARef.current = {
       request: undefined,
       response: undefined,
       abortController: undefined,
+      activeRequestId: currentQARef.current.activeRequestId + 1,
+      activeSessionId: currentSessionId,
     };
 
     return () => {
       currentQARef.current.abortController?.abort();
+      currentQARef.current.activeRequestId += 1;
     };
   }, [currentSessionId]);
 

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatController.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatController.tsx
@@ -9,30 +9,49 @@ import { InputProps } from "../Input";
 import useChatMessageHandler from "./useChatMessageHandler";
 import useChatRequest from "./useChatRequest";
 import useChatSessionHandler from "./useChatSessionHandler";
+import { useChatAnywhereOptions } from "../../Context/ChatAnywhereOptionsContext";
 import ReactDOM from "react-dom";
 // import mockdata from '../../mock/mock.json'
 
 /**
- * 聊天控制器 Hook - 协调所有聊天相关操作
+ * Chat controller hook — coordinates all chat-related operations.
  */
 export default function useChatController() {
   const setLoading = useContextSelector(ChatAnywhereInputContext, v => v.setLoading);
   const currentSessionId = useContextSelector(ChatAnywhereSessionsContext, v => v.currentSessionId);
+  const apiOptions = useChatAnywhereOptions(v => v.api);
+  const apiOptionsRef = useRef(apiOptions);
+  useEffect(() => {
+    apiOptionsRef.current = apiOptions;
+  }, [apiOptions]);
 
   const currentQARef = useRef<{
     request?: IAgentScopeRuntimeWebUIMessage;
     response?: IAgentScopeRuntimeWebUIMessage;
     abortController?: AbortController;
-  }>({});
+    /**
+     * Unique identifier for the currently active SSE request. Incremented on
+     * every new submit / cancel / session-switch. processSSEResponse checks its
+     * own requestId against this value before every write — a mismatch means
+     * the stream is stale and should stop writing (prevents cross-session
+     * leakage and ghost writes from cancelled runs, related to issue #4644).
+     */
+    activeRequestId: number;
+    /**
+     * Snapshot of the session id associated with the active request.
+     * Used to detect stale requests after a session switch.
+     */
+    activeSessionId?: string;
+  }>({ activeRequestId: 0 });
 
-  // 消息处理
+  // Message handler
   const messageHandler = useChatMessageHandler({ currentQARef });
 
-  // 会话处理
+  // Session handler
   const sessionHandler = useChatSessionHandler();
 
   /**
-   * 完成响应
+   * Finalize the current response and reset UI loading state.
    */
   const finishResponse = useCallback((status: 'finished' | 'interrupted' = 'finished') => {
     if (!currentQARef.current.response) return;
@@ -46,7 +65,7 @@ export default function useChatController() {
     sessionHandler.syncSessionMessages(messageHandler.getMessages());
   }, [setLoading, messageHandler, sessionHandler]);
 
-  // API 请求处理
+  // API request handling
   const { request, reconnect } = useChatRequest({
     currentQARef,
     updateMessage: messageHandler.updateMessage,
@@ -55,90 +74,133 @@ export default function useChatController() {
   });
 
   /**
-   * 处理用户提交
+   * Handle user message submission.
    */
   const handleSubmit = useCallback<InputProps['onSubmit']>(async (data) => {
-    // 1. 确保会话存在
+    // 0. Increment requestId and abort any previous in-flight SSE.
+    //    We do NOT call the cancel API here — the user is sending a new
+    //    message, not explicitly cancelling. Cancel is only invoked from
+    //    handleCancel.
+    currentQARef.current.abortController?.abort();
+    const myRequestId = ++currentQARef.current.activeRequestId;
+
+    // 1. Ensure session exists
     await sessionHandler.ensureSession(data.query);
 
-    // 2. 更新会话名称（如果是第一条消息）
+    // 2. Update session name (only for the first message)
     const messages = messageHandler.getMessages();
     if (sessionHandler.getCurrentSessionId()) {
       await sessionHandler.updateSessionName(data.query, messages);
     }
 
-    // 3. 创建用户请求消息
+    // Snapshot current session id for downstream SSE guard checks
+    currentQARef.current.activeSessionId = sessionHandler.getCurrentSessionId();
+
+    // 3. Create user request message
     messageHandler.createRequestMessage(data);
     setLoading(true);
     await sleep(100);
 
-    // 4. 创建助手响应消息
+    // If requestId changed during the sleep (session switch / cancel / new submit), bail out
+    if (myRequestId !== currentQARef.current.activeRequestId) return;
+
+    // 4. Create assistant response placeholder
     messageHandler.createResponseMessage();
 
-    // 5. 获取历史消息并发起请求
+    // 5. Gather history messages and fire the request
     const historyMessages = messageHandler.getHistoryMessages();
     await sessionHandler.syncSessionMessages(messageHandler.getMessages());
 
-    await request(historyMessages, data.biz_params);
+    await request(historyMessages, data.biz_params, myRequestId);
     // mockRequest(mockdata);
-  }, [messageHandler, sessionHandler, request]);
+  }, [messageHandler, sessionHandler, request, setLoading]);
 
 
   const handleApproval = useCallback(async ({ input }) => {
+    currentQARef.current.abortController?.abort();
+    const myRequestId = ++currentQARef.current.activeRequestId;
+    currentQARef.current.activeSessionId = sessionHandler.getCurrentSessionId();
+
     messageHandler.createApprovalMessage(input);
 
     setLoading(true);
     await sleep(100);
 
+    if (myRequestId !== currentQARef.current.activeRequestId) return;
+
     messageHandler.createResponseMessage();
     const historyMessages = messageHandler.getHistoryMessages();
     await sessionHandler.syncSessionMessages(messageHandler.getMessages());
 
-    await request(historyMessages);
-  }, [messageHandler, sessionHandler, request]);
+    await request(historyMessages, undefined, myRequestId);
+  }, [messageHandler, sessionHandler, request, setLoading]);
 
   /**
-   * 处理取消
-   * 1. 标记 interrupted 并重置 UI（finishResponse）
-   * 2. abort SSE 连接 —— Stream 内部的 Promise.race 会立即 reject AbortError，
-   *    processSSEResponse 的 catch 会检测 interrupted 状态并调用 cancel API
+   * Handle cancel / stop.
+   * 1. Mark response as interrupted and reset UI (finishResponse).
+   * 2. Invoke the cancel API immediately — do NOT wait for the next SSE
+   *    chunk to deliver the cancellation (fixes "backend keeps running
+   *    after stop" issue).
+   * 3. Abort the SSE connection.
+   * 4. Increment activeRequestId so any lingering SSE chunks from the
+   *    old run fail the isStillActive() guard and are discarded.
    */
   const handleCancel = useCallback(() => {
     finishResponse('interrupted');
+    const sessionId = sessionHandler.getCurrentSessionId();
+    const cancelFn = apiOptionsRef.current.cancel;
+    if (cancelFn && sessionId) {
+      try {
+        cancelFn({ session_id: sessionId });
+      } catch (e) {
+        console.error('cancel api failed:', e);
+      }
+    }
     currentQARef.current.abortController?.abort();
-  }, [finishResponse]);
+    // Increment requestId so un-aborted residual SSE chunks fail the guard
+    currentQARef.current.activeRequestId += 1;
+  }, [finishResponse, sessionHandler]);
 
   /**
-   * 处理重新生成
+   * Handle regenerate (retry the last assistant response).
    */
   const handleRegenerate = useCallback(async (messageId: string) => {
+    currentQARef.current.abortController?.abort();
+    const myRequestId = ++currentQARef.current.activeRequestId;
+    currentQARef.current.activeSessionId = sessionHandler.getCurrentSessionId();
+
     setLoading(true);
 
-    // 1. 移除旧消息
+    // 1. Remove old message
     messageHandler.removeMessageById(messageId);
 
-    // 2. 创建新的响应消息
+    // 2. Create new response placeholder
     currentQARef.current.abortController = new AbortController();
     messageHandler.createResponseMessage();
 
-    // 3. 发起请求
+    // 3. Fire the request
     const historyMessages = messageHandler.getHistoryMessages();
-    await request(historyMessages);
-  }, [messageHandler, request]);
+    await request(historyMessages, undefined, myRequestId);
+  }, [messageHandler, request, sessionHandler, setLoading]);
 
   /**
-   * 处理 SSE 重连（切回未完成的对话时）
+   * Handle SSE reconnection (when switching back to an unfinished conversation).
    * If the reconnect API returns no body or the stream ends without a completion event,
    * treat it as idle: remove the empty placeholder and reset loading.
    */
   const handleReconnect = useCallback(async (sessionId: string) => {
     currentQARef.current.abortController?.abort();
     currentQARef.current.abortController = new AbortController();
+    const myRequestId = ++currentQARef.current.activeRequestId;
+    currentQARef.current.activeSessionId = sessionId;
     setLoading(true);
 
     messageHandler.createResponseMessage();
 
-    await reconnect(sessionId);
+    await reconnect(sessionId, myRequestId);
+
+    // If session was switched or a new request fired during reconnect, bail out
+    if (myRequestId !== currentQARef.current.activeRequestId) return;
 
     // If the response is still in 'generating' state after reconnect completes,
     // onFinish() was never called (no response body, or stream closed without a completion event).
@@ -154,21 +216,26 @@ export default function useChatController() {
     }
   }, [messageHandler, reconnect, setLoading]);
 
-  // 监听会话切换，断开当前 SSE 连接（不通知后端取消）并重置状态
+  // On session switch: abort current SSE (without notifying backend cancel)
+  // and reset state. Also increment activeRequestId so any residual SSE
+  // chunks from the old session are discarded, preventing cross-session leakage.
   useEffect(() => {
     currentQARef.current.abortController?.abort();
     currentQARef.current = {
       request: undefined,
       response: undefined,
       abortController: undefined,
+      activeRequestId: currentQARef.current.activeRequestId + 1,
+      activeSessionId: currentSessionId,
     };
 
     return () => {
       currentQARef.current.abortController?.abort();
+      currentQARef.current.activeRequestId += 1;
     };
   }, [currentSessionId]);
 
-  // 监听重连事件
+  // Listen for reconnect events
   useChatAnywhereEventEmitter({
     type: 'handleReconnect',
     callback: async (data) => {
@@ -176,7 +243,7 @@ export default function useChatController() {
     }
   }, [handleReconnect]);
 
-  // 监听重新生成事件
+  // Listen for regenerate events
   useChatAnywhereEventEmitter({
     type: 'handleReplace',
     callback: async (data) => {

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatController.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatController.tsx
@@ -141,9 +141,18 @@ export default function useChatController() {
    * 2. Invoke the cancel API immediately — do NOT wait for the next SSE
    *    chunk to deliver the cancellation (fixes "backend keeps running
    *    after stop" issue).
-   * 3. Abort the SSE connection.
-   * 4. Increment activeRequestId so any lingering SSE chunks from the
-   *    old run fail the isStillActive() guard and are discarded.
+   * 3. Abort the SSE connection — its catch branch will see
+   *    msgStatus === 'interrupted' and call builder.cancel() to flip the
+   *    in-progress TEXT content to Canceled, so the trailing Markdown
+   *    cursor ("...") disappears.
+   *
+   * NOTE: we intentionally do NOT bump activeRequestId here. Doing so
+   * would make isStillActive() in processSSEResponse return false for
+   * this very cancel, which would short-circuit the catch branch before
+   * builder.cancel() runs and leave the trailing cursor blinking forever.
+   * Stale-chunk protection still holds: abort() breaks the SSE loop
+   * immediately, and the next submit / session switch will bump
+   * activeRequestId on its own.
    */
   const handleCancel = useCallback(() => {
     finishResponse('interrupted');
@@ -157,8 +166,6 @@ export default function useChatController() {
       }
     }
     currentQARef.current.abortController?.abort();
-    // Increment requestId so un-aborted residual SSE chunks fail the guard
-    currentQARef.current.activeRequestId += 1;
   }, [finishResponse, sessionHandler]);
 
   /**

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatRequest.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatRequest.tsx
@@ -122,7 +122,7 @@ export default function useChatRequest(options: UseChatRequestOptions) {
         const chunkData = responseParser(chunk.data);
         const res = agentScopeRuntimeResponseBuilder.handle(chunkData);
 
-        if (res.status !== AgentScopeRuntimeRunStatus.Failed && !res.output?.[0]?.content?.length) continue;
+        if (res.status !== AgentScopeRuntimeRunStatus.Failed && !res.output?.some(msg => msg.content?.length)) continue;
 
         if (currentQARef.current.response) {
           currentQARef.current.response.cards = [

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatRequest.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatRequest.tsx
@@ -11,6 +11,10 @@ interface UseChatRequestOptions {
     request?: IAgentScopeRuntimeWebUIMessage;
     response?: IAgentScopeRuntimeWebUIMessage;
     abortController?: AbortController;
+    /** 当前活跃请求 id，由 controller 维护。递增后会让正在跑的旧 SSE 校验失败。 */
+    activeRequestId: number;
+    /** 当前活跃请求的会话 id 快照。 */
+    activeSessionId?: string;
   }>;
   updateMessage: (message: IAgentScopeRuntimeWebUIMessage) => void;
   getCurrentSessionId: () => string;
@@ -57,13 +61,29 @@ export default function useChatRequest(options: UseChatRequestOptions) {
   }, [])
 
 
-  const processSSEResponse = useCallback(async (response: Response) => {
+  const processSSEResponse = useCallback(async (
+    response: Response,
+    myRequestId: number,
+    mySessionId?: string,
+  ) => {
     const currentApiOptions = apiOptionsRef.current;
     const agentScopeRuntimeResponseBuilder = new AgentScopeRuntimeResponseBuilder({
       id: '',
       status: AgentScopeRuntimeRunStatus.Created,
       created_at: 0,
     });
+
+    /**
+     * 守卫：当前 SSE 是否仍属于活跃请求。任何一个不匹配都应立即停止写入：
+     *   - requestId 不匹配：说明用户取消了 / 发了新消息 / 切了会话
+     *   - sessionId 不匹配：说明会话已被切走，避免串台
+     */
+    const isStillActive = () => {
+      if (currentQARef.current.activeRequestId !== myRequestId) return false;
+      if (mySessionId && currentQARef.current.activeSessionId &&
+          currentQARef.current.activeSessionId !== mySessionId) return false;
+      return true;
+    };
 
     if (!response.ok) {
       try {
@@ -79,16 +99,18 @@ export default function useChatRequest(options: UseChatRequestOptions) {
           message: JSON.stringify(data),
         });
 
-        currentQARef.current.response.cards = [
-          {
-            code: 'AgentScopeRuntimeResponseCard',
-            data: res,
-          }
-        ];
+        if (isStillActive() && currentQARef.current.response) {
+          currentQARef.current.response.cards = [
+            {
+              code: 'AgentScopeRuntimeResponseCard',
+              data: res,
+            }
+          ];
+        }
       } catch {
         // Ignore JSON parse errors — still call onFinish to reset loading state
       }
-      onFinish();
+      if (isStillActive()) onFinish();
       return;
     }
 
@@ -99,22 +121,23 @@ export default function useChatRequest(options: UseChatRequestOptions) {
         readableStream: response.body,
         signal: abortSignal,
       })) {
+        // 首要守卫：任何原因导致这条 SSE 不再是活跃的就立即退出，
+        // 不再调 updateMessage，避免“幽灵写入”。
+        if (!isStillActive()) break;
+
         if (currentQARef.current.response?.msgStatus === 'interrupted') {
           currentQARef.current.abortController?.abort();
-          if (currentApiOptions.cancel) {
-            currentApiOptions.cancel({
-              session_id: getCurrentSessionId(),
-            });
+          // cancel 已在 handleCancel 中主动发起，这里不重复发。
+
+          if (isStillActive() && currentQARef.current.response) {
+            currentQARef.current.response.cards = [
+              {
+                code: 'AgentScopeRuntimeResponseCard',
+                data: agentScopeRuntimeResponseBuilder.cancel(),
+              }
+            ];
+            updateMessage(currentQARef.current.response);
           }
-
-          currentQARef.current.response.cards = [
-            {
-              code: 'AgentScopeRuntimeResponseCard',
-              data: agentScopeRuntimeResponseBuilder.cancel(),
-            }
-          ];
-
-          updateMessage(currentQARef.current.response);
           break;
         }
 
@@ -123,6 +146,8 @@ export default function useChatRequest(options: UseChatRequestOptions) {
         const res = agentScopeRuntimeResponseBuilder.handle(chunkData);
 
         if (res.status !== AgentScopeRuntimeRunStatus.Failed && !res.output?.some(msg => msg.content?.length)) continue;
+
+        if (!isStillActive()) break;
 
         if (currentQARef.current.response) {
           currentQARef.current.response.cards = [
@@ -140,19 +165,21 @@ export default function useChatRequest(options: UseChatRequestOptions) {
         }
       }
     } catch (error) {
+      if (!isStillActive()) {
+        // 请求已不活跃，不要再写 cards / 发 cancel
+        return;
+      }
       if (currentQARef.current.response?.msgStatus === 'interrupted') {
-        if (currentApiOptions.cancel) {
-          currentApiOptions.cancel({
-            session_id: getCurrentSessionId(),
-          });
+        // cancel 已在 handleCancel 中主动发起，这里不重复。
+        if (currentQARef.current.response) {
+          currentQARef.current.response.cards = [
+            {
+              code: 'AgentScopeRuntimeResponseCard',
+              data: agentScopeRuntimeResponseBuilder.cancel(),
+            }
+          ];
+          updateMessage(currentQARef.current.response);
         }
-        currentQARef.current.response.cards = [
-          {
-            code: 'AgentScopeRuntimeResponseCard',
-            data: agentScopeRuntimeResponseBuilder.cancel(),
-          }
-        ];
-        updateMessage(currentQARef.current.response);
       } else {
         console.error(error);
       }
@@ -160,10 +187,16 @@ export default function useChatRequest(options: UseChatRequestOptions) {
   }, [getCurrentSessionId, currentQARef, updateMessage, onFinish]);
 
 
-  const request = useCallback(async (historyMessages: any[], biz_params?: IAgentScopeRuntimeWebUIInputData['biz_params']) => {
+  const request = useCallback(async (
+    historyMessages: any[],
+    biz_params?: IAgentScopeRuntimeWebUIInputData['biz_params'],
+    myRequestId?: number,
+  ) => {
     const currentApiOptions = apiOptionsRef.current;
     const { enableHistoryMessages = false } = currentApiOptions;
     const abortSignal = currentQARef.current.abortController?.signal;
+    const requestId = myRequestId ?? currentQARef.current.activeRequestId;
+    const sessionId = currentQARef.current.activeSessionId ?? getCurrentSessionId();
     let response
     try {
       response = currentApiOptions.fetch ? await currentApiOptions.fetch({
@@ -188,15 +221,16 @@ export default function useChatRequest(options: UseChatRequestOptions) {
     }
 
     if (response && response.body) {
-      await processSSEResponse(response);
+      await processSSEResponse(response, requestId, sessionId);
     }
   }, [getCurrentSessionId, currentQARef, processSSEResponse]);
 
-  const reconnect = useCallback(async (sessionId: string) => {
+  const reconnect = useCallback(async (sessionId: string, myRequestId?: number) => {
     const currentApiOptions = apiOptionsRef.current;
     if (!currentApiOptions.reconnect) return;
 
     const abortSignal = currentQARef.current.abortController?.signal;
+    const requestId = myRequestId ?? currentQARef.current.activeRequestId;
     let response: Response | undefined;
     try {
       response = await currentApiOptions.reconnect({
@@ -207,7 +241,7 @@ export default function useChatRequest(options: UseChatRequestOptions) {
     }
 
     if (response && response.body) {
-      await processSSEResponse(response);
+      await processSSEResponse(response, requestId, sessionId);
     }
   }, [currentQARef, processSSEResponse]);
 

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatRequest.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/hooks/useChatRequest.tsx
@@ -11,6 +11,10 @@ interface UseChatRequestOptions {
     request?: IAgentScopeRuntimeWebUIMessage;
     response?: IAgentScopeRuntimeWebUIMessage;
     abortController?: AbortController;
+    /** Active request id, maintained by the controller. Incrementing it invalidates any in-flight SSE. */
+    activeRequestId: number;
+    /** Session id snapshot for the active request. */
+    activeSessionId?: string;
   }>;
   updateMessage: (message: IAgentScopeRuntimeWebUIMessage) => void;
   getCurrentSessionId: () => string;
@@ -18,13 +22,13 @@ interface UseChatRequestOptions {
 }
 
 /**
- * 处理 API 请求和流式响应的 Hook
+ * Hook for handling API requests and streaming SSE responses.
  */
 export default function useChatRequest(options: UseChatRequestOptions) {
   const { currentQARef, updateMessage, getCurrentSessionId, onFinish } = options;
   const apiOptions = useChatAnywhereOptions(v => v.api);
 
-  // 使用 ref 保存最新的 apiOptions，避免闭包陷阱
+  // Keep apiOptions in a ref to avoid stale closure issues
   const apiOptionsRef = useRef(apiOptions);
 
   useEffect(() => {
@@ -57,13 +61,30 @@ export default function useChatRequest(options: UseChatRequestOptions) {
   }, [])
 
 
-  const processSSEResponse = useCallback(async (response: Response) => {
+  const processSSEResponse = useCallback(async (
+    response: Response,
+    myRequestId: number,
+    mySessionId?: string,
+  ) => {
     const currentApiOptions = apiOptionsRef.current;
     const agentScopeRuntimeResponseBuilder = new AgentScopeRuntimeResponseBuilder({
       id: '',
       status: AgentScopeRuntimeRunStatus.Created,
       created_at: 0,
     });
+
+    /**
+     * Guard: check whether this SSE stream is still the active request.
+     * If any of the following is true, writing should stop immediately:
+     *   - requestId mismatch: user cancelled / sent new message / switched session
+     *   - sessionId mismatch: session was switched away, prevents cross-session leakage
+     */
+    const isStillActive = () => {
+      if (currentQARef.current.activeRequestId !== myRequestId) return false;
+      if (mySessionId && currentQARef.current.activeSessionId &&
+          currentQARef.current.activeSessionId !== mySessionId) return false;
+      return true;
+    };
 
     if (!response.ok) {
       try {
@@ -79,16 +100,18 @@ export default function useChatRequest(options: UseChatRequestOptions) {
           message: JSON.stringify(data),
         });
 
-        currentQARef.current.response.cards = [
-          {
-            code: 'AgentScopeRuntimeResponseCard',
-            data: res,
-          }
-        ];
+        if (isStillActive() && currentQARef.current.response) {
+          currentQARef.current.response.cards = [
+            {
+              code: 'AgentScopeRuntimeResponseCard',
+              data: res,
+            }
+          ];
+        }
       } catch {
         // Ignore JSON parse errors — still call onFinish to reset loading state
       }
-      onFinish();
+      if (isStillActive()) onFinish();
       return;
     }
 
@@ -99,22 +122,23 @@ export default function useChatRequest(options: UseChatRequestOptions) {
         readableStream: response.body,
         signal: abortSignal,
       })) {
+        // Primary guard: if this SSE is no longer active, stop immediately
+        // to prevent ghost writes into a different session/request.
+        if (!isStillActive()) break;
+
         if (currentQARef.current.response?.msgStatus === 'interrupted') {
           currentQARef.current.abortController?.abort();
-          if (currentApiOptions.cancel) {
-            currentApiOptions.cancel({
-              session_id: getCurrentSessionId(),
-            });
+          // Cancel was already sent by handleCancel; don't repeat it here.
+
+          if (isStillActive() && currentQARef.current.response) {
+            currentQARef.current.response.cards = [
+              {
+                code: 'AgentScopeRuntimeResponseCard',
+                data: agentScopeRuntimeResponseBuilder.cancel(),
+              }
+            ];
+            updateMessage(currentQARef.current.response);
           }
-
-          currentQARef.current.response.cards = [
-            {
-              code: 'AgentScopeRuntimeResponseCard',
-              data: agentScopeRuntimeResponseBuilder.cancel(),
-            }
-          ];
-
-          updateMessage(currentQARef.current.response);
           break;
         }
 
@@ -123,6 +147,8 @@ export default function useChatRequest(options: UseChatRequestOptions) {
         const res = agentScopeRuntimeResponseBuilder.handle(chunkData);
 
         if (res.status !== AgentScopeRuntimeRunStatus.Failed && !res.output?.some(msg => msg.content?.length)) continue;
+
+        if (!isStillActive()) break;
 
         if (currentQARef.current.response) {
           currentQARef.current.response.cards = [
@@ -140,19 +166,21 @@ export default function useChatRequest(options: UseChatRequestOptions) {
         }
       }
     } catch (error) {
+      if (!isStillActive()) {
+        // Request is no longer active; do not write cards or fire cancel.
+        return;
+      }
       if (currentQARef.current.response?.msgStatus === 'interrupted') {
-        if (currentApiOptions.cancel) {
-          currentApiOptions.cancel({
-            session_id: getCurrentSessionId(),
-          });
+        // Cancel was already sent by handleCancel; don't repeat it here.
+        if (currentQARef.current.response) {
+          currentQARef.current.response.cards = [
+            {
+              code: 'AgentScopeRuntimeResponseCard',
+              data: agentScopeRuntimeResponseBuilder.cancel(),
+            }
+          ];
+          updateMessage(currentQARef.current.response);
         }
-        currentQARef.current.response.cards = [
-          {
-            code: 'AgentScopeRuntimeResponseCard',
-            data: agentScopeRuntimeResponseBuilder.cancel(),
-          }
-        ];
-        updateMessage(currentQARef.current.response);
       } else {
         console.error(error);
       }
@@ -160,10 +188,16 @@ export default function useChatRequest(options: UseChatRequestOptions) {
   }, [getCurrentSessionId, currentQARef, updateMessage, onFinish]);
 
 
-  const request = useCallback(async (historyMessages: any[], biz_params?: IAgentScopeRuntimeWebUIInputData['biz_params']) => {
+  const request = useCallback(async (
+    historyMessages: any[],
+    biz_params?: IAgentScopeRuntimeWebUIInputData['biz_params'],
+    myRequestId?: number,
+  ) => {
     const currentApiOptions = apiOptionsRef.current;
     const { enableHistoryMessages = false } = currentApiOptions;
     const abortSignal = currentQARef.current.abortController?.signal;
+    const requestId = myRequestId ?? currentQARef.current.activeRequestId;
+    const sessionId = currentQARef.current.activeSessionId ?? getCurrentSessionId();
     let response
     try {
       response = currentApiOptions.fetch ? await currentApiOptions.fetch({
@@ -188,15 +222,16 @@ export default function useChatRequest(options: UseChatRequestOptions) {
     }
 
     if (response && response.body) {
-      await processSSEResponse(response);
+      await processSSEResponse(response, requestId, sessionId);
     }
   }, [getCurrentSessionId, currentQARef, processSSEResponse]);
 
-  const reconnect = useCallback(async (sessionId: string) => {
+  const reconnect = useCallback(async (sessionId: string, myRequestId?: number) => {
     const currentApiOptions = apiOptionsRef.current;
     if (!currentApiOptions.reconnect) return;
 
     const abortSignal = currentQARef.current.abortController?.signal;
+    const requestId = myRequestId ?? currentQARef.current.activeRequestId;
     let response: Response | undefined;
     try {
       response = await currentApiOptions.reconnect({
@@ -207,7 +242,7 @@ export default function useChatRequest(options: UseChatRequestOptions) {
     }
 
     if (response && response.body) {
-      await processSSEResponse(response);
+      await processSSEResponse(response, requestId, sessionId);
     }
   }, [currentQARef, processSSEResponse]);
 

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.ts
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.ts
@@ -68,6 +68,12 @@ export interface IAgentScopeRuntimeWebUIAPIOptions {
    * @descriptionEn Custom media URL transformer (e.g. sign URL, replace CDN domain)
    */
   replaceMediaURL?: (url: string) => string;
+
+  /**
+   * @description 自定义文件点击事件（桌面端可通过此钩子调用原生 API 打开文件链接），不传则默认 window.open
+   * @descriptionEn Custom file click handler (desktop apps can use native APIs to open file URLs), defaults to window.open
+   */
+  onFileCardClick?: (file: { url?: string; name?: string; size?: number }) => void;
 }
 
 /**

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.ts
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.ts
@@ -453,6 +453,7 @@ export interface IAgentScopeRuntimeWebUIActionsOptions {
    */
   list: {
     icon?: React.ReactElement;
+    children?: React.ReactElement;
     render?: ({
       data,
     }: {
@@ -467,6 +468,7 @@ export interface IAgentScopeRuntimeWebUIActionsOptions {
    */
   right?: false | {
     icon?: React.ReactElement;
+    children?: React.ReactElement;
     render?: ({ data }: { data: IAgentScopeRuntimeResponse }) => React.ReactElement;
     onClick?: ({ data }: { data: IAgentScopeRuntimeResponse }) => void;
   }[];

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.ts
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.ts
@@ -441,6 +441,7 @@ export interface IAgentScopeRuntimeWebUIRequestActionsOptions {
   list?: {
     icon?: React.ReactElement;
     children?: React.ReactElement;
+    render?: ({ data }: { data: IAgentScopeRuntimeRequest }) => React.ReactElement;
     onClick?: ({ data }: { data: IAgentScopeRuntimeRequest }) => void;
   }[];
 }

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.ts
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.ts
@@ -440,6 +440,7 @@ export interface IAgentScopeRuntimeWebUIRequestActionsOptions {
    */
   list?: {
     icon?: React.ReactElement;
+    children?: React.ReactElement;
     onClick?: ({ data }: { data: IAgentScopeRuntimeRequest }) => void;
   }[];
 }

--- a/packages/spark-chat/components/DefaultCards/Files/index.tsx
+++ b/packages/spark-chat/components/DefaultCards/Files/index.tsx
@@ -56,7 +56,11 @@ export default function Files(props) {
 
           {
             fileInfo.url && <div className={`${prefixCls}-download`} onClick={() => {
-              window.open(fileInfo.url, '_blank');
+              if (props.onClick) {
+                props.onClick(fileInfo);
+              } else {
+                window.open(fileInfo.url, '_blank');
+              }
             }}>
               <SparkDownloadLine />
             </div>

--- a/packages/spark-chat/components/Markdown/Markdown.tsx
+++ b/packages/spark-chat/components/Markdown/Markdown.tsx
@@ -88,11 +88,12 @@ export default memo(function (props: MarkdownProps) {
   const config = useMemo(() => ({
     extensions,
     walkTokens,
-    // 当 allowHtml 为 false 时，转义 HTML 标签使其显示为字符串
+    // 当 allowHtml 为 false 时，仅放行安全的内联 HTML 标签，其余转义
     ...(!allowHtml && {
       renderer: {
         html(token: { text?: string; raw?: string }) {
           const text = token.text || token.raw || '';
+          if (/^<br\s*\/?>$/i.test(text.trim())) return '<br />';
           return text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
         }
       }

--- a/packages/spark-chat/package-lock.json
+++ b/packages/spark-chat/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentscope-ai/chat",
-  "version": "1.1.63",
+  "version": "1.1.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentscope-ai/chat",
-      "version": "1.1.63",
+      "version": "1.1.64",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentscope-ai/icons": "^1.0.32",

--- a/packages/spark-chat/package.json
+++ b/packages/spark-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentscope-ai/chat",
-  "version": "1.1.63",
+  "version": "1.1.64",
   "description": "a free and open-source chat framework for building excellent LLM-powered chat experiences",
   "license": "Apache-2.0",
   "sideEffects": [


### PR DESCRIPTION
## Summary

- **SSE lifecycle race fixes** (`useChatController` / `useChatRequest`): introduce `activeRequestId` + `activeSessionId` tracking guarded by `isStillActive()` on every SSE write. Fixes cross-session leakage, ghost writes from cancelled runs, and the regression where existing sessions silently dropped messages because the session-switch effect bumped the request id during initial mount / no-op transitions.
- **Cancel UX** (`useChatController` / `useChatRequest`): cancel API is now invoked immediately from `handleCancel` instead of waiting for the next SSE chunk (fixes "backend keeps running after stop"). `activeRequestId` is intentionally NOT bumped on cancel so the SSE catch branch can still flip the in-progress TEXT card to Canceled — eliminates the trailing Markdown cursor残留.
- **Tool-call streaming merge** (`Response/Builder`): merge incoming `output` with previously accumulated output by id, preferring the version with non-empty content. Stops a partial-update response from wiping out tool-call messages already collected (Bug 2 of #4644).
- **`onFileCardClick` API hook** (`IChatAnywhere` / `Request/Card` / `Response/Message` / `DefaultCards/Files`): lets desktop-shell hosts open file URLs via native APIs; falls back to `window.open`.
- **Action `render` / `children` support** in request actions, plus shallow-copy fix in response actions to stop mutating the original options.
- **Request `created_at`**: client-side send timestamp (seconds) on every request, aligned with response `created_at`.
- **Markdown**: when `allowHtml=false`, allow `<br>` through instead of escaping it.
- **Version bump**: `@agentscope-ai/chat` 1.1.65 → 1.1.67.

## Test plan

- [ ] Send a message in an existing session — request fires, response streams, no silent drop.
- [ ] Switch sessions mid-stream — old SSE chunks do not leak into the new session; no ghost writes.
- [ ] Click Stop while streaming — backend cancel API fires immediately; in-progress card flips to Canceled with no trailing cursor.
- [ ] Tool-call run with intermediate partial-update responses — accumulated tool-call messages are preserved (no flicker / disappear).
- [ ] Provide `api.onFileCardClick` — request and response file cards both invoke it; without it, `window.open` is used.
- [ ] Pass `requestActions.list[].render` — custom node renders inside the action button.
- [ ] Markdown content containing `<br>` renders as a line break when `allowHtml=false`; other tags remain escaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)