### PR TITLE
fix(spark-chat): 规范 images 参数类型处理，防止异常数据渲染

### DIFF
--- a/packages/spark-chat/components/OperateCard/preset/Rag.tsx
+++ b/packages/spark-chat/components/OperateCard/preset/Rag.tsx
@@ -58,10 +58,27 @@ export interface IRagProps {
   filters?: string;
 }
 
-function Images({ images }: { images: string[] }) {
+// 兼容上游传入的 images 类型不规范（如单个字符串、null 等），统一归一化为字符串数组
+function normalizeImages(images?: string[] | string | null): string[] {
+  if (Array.isArray(images)) {
+    return images.filter((image): image is string => typeof image === 'string' && !!image);
+  }
+  if (typeof images === 'string' && images) {
+    return [images];
+  }
+  return [];
+}
+
+function Images({ images }: { images?: string[] | string | null }) {
   const { getPrefixCls } = useProviderContext();
 
   const prefixCls = getPrefixCls('operate-card');
+
+  const imageList = normalizeImages(images);
+
+  if (!imageList.length) {
+    return null;
+  }
 
   return <ConfigProvider
     locale={{
@@ -69,7 +86,7 @@ function Images({ images }: { images: string[] }) {
     } as Locale}
   >
     <Image.PreviewGroup>
-      {images.map((image, index) => <Image src={image} key={index} width={44} height={44} />)}
+      {imageList.map((image, index) => <Image src={image} key={index} width={44} height={44} />)}
     </Image.PreviewGroup>
   </ConfigProvider>
 
@@ -106,10 +123,10 @@ function Item({ item }) {
         <div className={`${prefixCls}-rag-item-content-text`}>{item.content}</div>
 
         {
-          item.images &&
+          normalizeImages(item.images).length ?
           <div className={`${prefixCls}-rag-item-images`}>
             <Images images={item.images} />
-          </div>
+          </div> : null
         }
 
         {
@@ -146,7 +163,7 @@ export default function (props: IRagProps) {
     </div>
 
     {
-      images?.length ? <div>
+      normalizeImages(images).length ? <div>
         <div className={`${prefixCls}-rag-group-title`}>检索图片</div>
         <div className={`${prefixCls}-rag-group-content ${prefixCls}-rag-group-content-images`}>
           <Images images={images} />


### PR DESCRIPTION
- 新增 normalizeImages 方法，兼容字符串、数组及 null 等多种 images 类型
- 将 Images 组件内 images 参数规范为字符串数组，过滤无效值
- 所有使用 images 的地方统一调用 normalizeImages 进行类型归一化
- 避免 images 类型不规范导致的渲染崩溃或异常显示问题
- 保持图片预览与展示功能一致性，提高组件健壮性

## 变更类型

- [ ] feat（新增功能）
- [✅] fix（问题修复）
- [ ] docs（文档）
- [ ] chore（工程/构建/依赖）
- [ ] refactor（重构）
- [ ] perf（性能优化）
- [ ] test（测试）

## 影响范围（必填）

- [ ] `@agentscope-ai/design`（packages/spark-design）
- [✅] `@agentscope-ai/chat`（packages/spark-chat）
- [ ] `@agentscope-ai/flow`（packages/spark-flow）
- [ ] `@agentscope-ai/clawd-chat-ui`（packages/clawd-chat-ui）
- [ ] 仅仓库工程（不影响 npm 包）

## 变更说明

<!-- 简述做了什么、为什么做、怎么验证 -->
修改了chat组件中Rag工具对于images的兼容，兼容array和string类型。之前string类型组件会崩溃。

## 验证方式

- [✅] 本地已通过：`pnpm run lint`
- [✅] 本地已通过：`pnpm run build`
- [ ] 本地已通过（如涉及）：`pnpm run docs:build`

## 发布影响（Maintainer 填）

- [ ] 需要发版
- [ ] 不需要发版

> 建议 PR 标题使用 Conventional Commits，例如：`feat(design): xxx`。
> 仓库会强制 Squash Merge，最终提交信息默认取 PR 标题。


