### PR TITLE
feat(chat): expose custom sender input component

### DIFF
--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/Input/index.tsx
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/Chat/Input/index.tsx
@@ -31,6 +31,7 @@ export default function Input(props: InputProps) {
     prefix,
     allowSpeech,
     suggestions,
+    components,
   } = senderOptions || {};
 
   const {
@@ -81,6 +82,7 @@ export default function Input(props: InputProps) {
         onPasteFile={handlePasteFile}
         onDropFile={handleDropFile}
         suggestions={suggestions}
+        components={components}
       />
       {afterUI}
     </div>

--- a/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.ts
+++ b/packages/spark-chat/components/AgentScopeRuntimeWebUI/core/types/IChatAnywhere.ts
@@ -6,6 +6,7 @@ import {
   IContent,
 } from '../AgentScopeRuntime/types';
 import { IAgentScopeRuntimeWebUISession } from './ISessions';
+import type { SenderComponents } from '../../../Sender';
 
 /**
  * @description API 配置选项
@@ -273,6 +274,11 @@ export interface IAgentScopeRuntimeWebUISenderActionInfo {
  * @descriptionEn Sender configuration options
  */
 export interface IAgentScopeRuntimeWebUISenderOptions {
+  /**
+   * @description 自定义输入组件
+   * @descriptionEn Custom input component
+   */
+  components?: SenderComponents;
   /**
    * @description 输入框占位符
    * @descriptionEn Input placeholder

--- a/packages/spark-chat/components/Sender/demo/customInput.tsx
+++ b/packages/spark-chat/components/Sender/demo/customInput.tsx
@@ -1,0 +1,28 @@
+import { ChatInput } from '@agentscope-ai/chat';
+import { Input } from 'antd';
+import React, { useState } from 'react';
+
+const CustomInput = React.forwardRef<
+  React.ElementRef<typeof Input.TextArea>,
+  React.ComponentProps<typeof Input.TextArea>
+>(function CustomInput(props, ref) {
+  return (
+    <Input.TextArea
+      {...props}
+      ref={ref}
+      style={{ ...props.style, color: '#1677ff' }}
+    />
+  );
+});
+
+export default function () {
+  const [value, setValue] = useState('Custom input component');
+
+  return (
+    <ChatInput
+      components={{ input: CustomInput }}
+      value={value}
+      onChange={setValue}
+    />
+  );
+}

--- a/packages/spark-chat/components/Sender/index.en-US.md
+++ b/packages/spark-chat/components/Sender/index.en-US.md
@@ -24,6 +24,7 @@ The following are examples and variations of this component
 <code src="./demo/suggestions.tsx" center height="350">Suggestions</code>
 <code src="./demo/beforeUI.tsx" center height="350">Before UI</code>
 <code src="./demo/morePrefixAction.tsx" center height="350">Custom Functionality</code>
+<code src="./demo/customInput.tsx" center height="350">Custom Input Component</code>
 <code src="./demo/asr.tsx" center height="350">Voice Input</code>
 
 #### API

--- a/packages/spark-chat/components/Sender/index.tsx
+++ b/packages/spark-chat/components/Sender/index.tsx
@@ -267,7 +267,11 @@ export interface SenderProps extends Pick<TextareaProps, 'placeholder' | 'onKeyP
    */
   onDropFile?: (file: File) => void;
   // prefixCls?: string;
-  // components?: SenderComponents;
+  /**
+   * @description 自定义输入组件
+   * @descriptionEn Custom input component
+   */
+  components?: SenderComponents;
 }
 
 export type SenderRef = {

--- a/packages/spark-chat/components/Sender/index.zh-CN.md
+++ b/packages/spark-chat/components/Sender/index.zh-CN.md
@@ -23,6 +23,7 @@ description: AI输入框
 <code src="./demo/moreMode.tsx" center height="350">自定义模式</code>
 <code src="./demo/suggestions.tsx" center height="350">输入建议</code>
 <code src="./demo/morePrefixAction.tsx" center height="350">自定义功能</code>
+<code src="./demo/customInput.tsx" center height="350">自定义输入组件</code>
 <code src="./demo/asr.tsx" center height="350">语音发送</code>
 
 


### PR DESCRIPTION
## 变更类型

- [x] feat（新增功能）
- [ ] fix（问题修复）
- [x] docs（文档）
- [ ] chore（工程/构建/依赖）
- [ ] refactor（重构）
- [ ] perf（性能优化）
- [ ] test（测试）

## 影响范围（必填）

- [ ] `@agentscope-ai/design`（packages/spark-design）
- [x] `@agentscope-ai/chat`（packages/spark-chat）
- [ ] `@agentscope-ai/flow`（packages/spark-flow）
- [ ] `@agentscope-ai/clawd-chat-ui`（packages/clawd-chat-ui）
- [ ] 仅仓库工程（不影响 npm 包）

## 变更说明

Expose the existing `SenderComponents` input override through both `SenderProps` and `IAgentScopeRuntimeWebUISenderOptions`, then forward it from `AgentScopeRuntimeWebUI` to `Sender`.

`Sender` already resolves `components.input` internally, but the prop was not publicly typed and the runtime WebUI did not forward it. Consumers that need a rich or domain-specific composer therefore have to patch the published package.

This keeps the extension generic: custom inputs receive the existing textarea-compatible value, event, and ref contract. A runnable custom-input demo and bilingual documentation entry are included.

A current consumer is agentscope-ai/QwenPaw#6504, which uses the extension for atomic file-reference chips in a rich composer.

## 验证方式

- [x] Changed TypeScript files pass targeted ESLint
- [x] `npm run src:build`
- [x] `npm run docs:build`

## 发布影响（Maintainer 填）

- [ ] 需要发版
- [ ] 不需要发版
